### PR TITLE
Fix import with scipy 1.6

### DIFF
--- a/xrscipy/integrate.py
+++ b/xrscipy/integrate.py
@@ -43,8 +43,10 @@ def inject_docs(func, func_name, description=None):
     except errors.NoDocstringError:
         return
 
+    if 'y' in doc.parameters:
+        doc.replace_params(
+            y='obj : xarray object\n' + doc.parameters['y'][1])
     doc.replace_params(
-        y='obj : xarray object\n' + doc.parameters['y'][1],
         axis='coord : string\n    The coordinate along which to integrate.\n')
     doc.remove_params('dx', 'x')
 

--- a/xrscipy/integrate.py
+++ b/xrscipy/integrate.py
@@ -75,14 +75,31 @@ def inject_docs(func, func_name, description=None):
     func.__name__ = func_name
 
 
+romb = partial(_wrap, integrate.romb, True)
+inject_docs(romb, 'romb', description='romb(obj, coord, show=False)')
+
+# scipy >= 1.6.0
+if hasattr(integrate, 'trapezoid'):
+    trapezoid = partial(_wrap, integrate.trapezoid, True)
+    inject_docs(trapezoid, 'trapezoid', description='trapezoid(obj, coord)')
+
+if hasattr(integrate, 'simpson'):
+    simpson = partial(_wrap, integrate.simpson, True)
+    inject_docs(simpson, 'simpson',
+                description='simpson(obj, coord, even=\'avg\')')
+
+if hasattr(integrate, 'cumulative_trapezoid'):
+    cumulative_trapezoid = partial(_wrap, integrate.cumulative_trapezoid,
+                                   False, initial=0)
+    inject_docs(cumulative_trapezoid, 'cumulative_trapezoid',
+                description='cumulative_trapezoid(obj, coord)')
+
+# scipy < 1.6.0
 trapz = partial(_wrap, integrate.trapz, True)
 inject_docs(trapz, 'trapz', description='trapz(obj, coord)')
 
 simps = partial(_wrap, integrate.simps, True)
 inject_docs(simps, 'simps', description='simps(obj, coord, even=\'avg\')')
-
-romb = partial(_wrap, integrate.romb, True)
-inject_docs(romb, 'romb', description='romb(obj, coord, show=False)')
 
 cumtrapz = partial(_wrap, integrate.cumtrapz, False, initial=0)
 inject_docs(cumtrapz, 'cumtrapz', description='cumtrapz(obj, coord)')

--- a/xrscipy/tests/test_integrate.py
+++ b/xrscipy/tests/test_integrate.py
@@ -9,8 +9,20 @@ from xrscipy.docs import DocParser
 from .testings import get_obj
 
 
+_trapz_funcs = [integrate.trapz]
+_trapz_names = ['trapz']
+_cumtrapz_names = ['cumtrapz']
+_simps_names = ['simps']
+_romb_names = ['romb']
+if hasattr(integrate, 'trapezoid'):  # scipy >= 1.6.0
+    _trapz_funcs += [integrate.trapezoid]
+    _trapz_names += ['trapezoid']
+    _cumtrapz_names += ['cumulative_trapezoid']
+    _simps_names += ['simpson']
+
+
 @pytest.mark.parametrize('mode', [1, 1])
-@pytest.mark.parametrize('func', ['trapz', 'cumtrapz'])
+@pytest.mark.parametrize('func', _trapz_names + _cumtrapz_names)
 @pytest.mark.parametrize('dim', ['x', 'time'])
 def test_integrate(mode, func, dim):
     da = get_obj(mode)
@@ -18,7 +30,7 @@ def test_integrate(mode, func, dim):
     axis = da.get_axis_num(da[dim].dims[0])
     actual = getattr(integrate, func)(da, dim)
     kwargs = {}
-    if func == 'cumtrapz':
+    if func in _cumtrapz_names:
         kwargs['initial'] = 0
     expected = getattr(sp.integrate, func)(da.values, x=da[dim].values,
                                            axis=axis, **kwargs)
@@ -33,36 +45,41 @@ def test_integrate(mode, func, dim):
             assert da[key].identical(actual[key])
 
 
-def test_integrate_dataset():
+@pytest.mark.parametrize('trapz_func', _trapz_funcs)
+def test_integrate_dataset(trapz_func):
     ds = get_obj(mode=3)
 
-    actual = integrate.trapz(ds, coord='z')
+    actual = trapz_func(ds, coord='z')
     assert actual['a'].identical(ds['a'])
     assert actual['b'].identical(integrate.trapz(ds['b'], coord='z'))
 
 
-def test_integrate_error():
+@pytest.mark.parametrize('trapz_func', _trapz_funcs)
+def test_integrate_error(trapz_func):
     # not sorted
     da = xr.DataArray([0, 1, 2], dims=['x'], coords={'x': [2, 3, 0]})
     with pytest.raises(ValueError):
-        integrate.trapz(da, 'x')
+        trapz_func(da, 'x')
 
     # wrong argument
     with pytest.raises(TypeError):
-        integrate.trapz(da, axis='x')
+        trapz_func(da, axis='x')
 
 
-@pytest.mark.parametrize('func', ['trapz', 'cumtrapz', 'simps', 'romb'])
+@pytest.mark.parametrize(
+    'func',
+    _trapz_names + _cumtrapz_names + _simps_names + _romb_names)
 def test_doc_all(func):
-    parser = DocParser(integrate.trapz.__doc__)
+    parser = DocParser(func.__doc__)
 
     not_included_keys = ['x', 'axis', 'dx']
     for k in not_included_keys:
         assert k not in parser.parameters.keys()
 
 
-def test_doc():
-    parser = DocParser(integrate.trapz.__doc__)
+@pytest.mark.parametrize('trapz_func', _trapz_funcs)
+def test_doc(trapz_func):
+    parser = DocParser(trapz_func.__doc__)
 
     not_included_keys = ['x', 'axis', 'dx']
     for k in not_included_keys:


### PR DESCRIPTION
Fixes #8 

Adds new methods `integrate.trapezoid`, `integrate.simpson` and `integrate.cumulative_trapezoid` and makes  `integrate.trapz`, `integrate.simps` and `integrate.cumtrapz` compatible with scipy >= 1.6.0.